### PR TITLE
21 on new infineon icons release trigger version update in infineon stencil library

### DIFF
--- a/.github/workflows/update-version-in-stencil-library.yml
+++ b/.github/workflows/update-version-in-stencil-library.yml
@@ -1,0 +1,24 @@
+name: Trigger Infineon/infineon-design-system-stencil update
+
+on:
+  workflow_run:
+    workflows: ["Deploy Library to GitHub"]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  send_repo_dispatch_event:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.REPO_DISPATCH_TOKEN }}
+          script: |
+            const result = await github.rest.repos.createDispatchEvent({
+              owner: 'Infineon',
+              repo: 'Infineon-Design-System-Stencil',
+              event_type: 'infineon_icons_release',
+              client_payload: {}
+            })
+            console.log(result);

--- a/.github/workflows/update-version-in-stencil-library.yml
+++ b/.github/workflows/update-version-in-stencil-library.yml
@@ -23,10 +23,15 @@ jobs:
         with:
           github-token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           script: |
-            const result = await github.rest.repos.createDispatchEvent({
-              owner: 'Infineon',
-              repo: 'Infineon-Design-System-Stencil',
-              event_type: 'infineon_icons_release',
-              client_payload: {"version": "v5.3.10"}
-              })
-            console.log(result);
+            try {
+              const result = await github.rest.repos.createDispatchEvent({
+                owner: 'Infineon',
+                repo: 'Infineon-Design-System-Stencil',
+                event_type: 'infineon_icons_release',
+                client_payload: {"version": "v5.3.10"}
+              });
+              console.log(result);
+            } catch (error) {
+              console.error(error);
+            }
+          

--- a/.github/workflows/update-version-in-stencil-library.yml
+++ b/.github/workflows/update-version-in-stencil-library.yml
@@ -1,10 +1,18 @@
 name: Trigger Infineon/infineon-design-system-stencil update
 
-on:
-  workflow_run:
-    workflows: ["Deploy Library to GitHub"]
+# on:
+#   workflow_run:
+#     workflows: ["Deploy Library to GitHub"]
+#     types:
+#       - completed
+
+on: #just for testing
+  pull_request:
     types:
-      - completed
+      - opened
+      - reopened
+      - synchronize # canary on new commit
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-version-in-stencil-library.yml
+++ b/.github/workflows/update-version-in-stencil-library.yml
@@ -27,6 +27,6 @@ jobs:
               owner: 'Infineon',
               repo: 'Infineon-Design-System-Stencil',
               event_type: 'infineon_icons_release',
-              client_payload: {}
-            })
+              client_payload: {"version": "v5.3.10"}
+              })
             console.log(result);

--- a/.github/workflows/update-version-in-stencil-library.yml
+++ b/.github/workflows/update-version-in-stencil-library.yml
@@ -23,15 +23,10 @@ jobs:
         with:
           github-token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           script: |
-            try {
-              const result = await github.rest.repos.createDispatchEvent({
-                owner: 'Infineon',
-                repo: 'Infineon-Design-System-Stencil',
-                event_type: 'infineon_icons_release',
-                client_payload: {"version": "v5.3.10"}
-              });
-              console.log(result);
-            } catch (error) {
-              console.error(error);
-            }
-          
+            const result = await github.rest.repos.createDispatchEvent({
+              owner: 'Infineon',
+              repo: 'infineon-design-system-stencil',
+              event_type: 'infineon_icons_release',
+              client_payload: {"version": "v5.3.10"}
+              })
+            console.log(result);


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Test - on new infineon icons release create a PR in infineon stencil library
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.8--canary.22.da4d6ee21f31cf2a3b2349ae41499048572fc0e9.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-icons@1.1.8--canary.22.da4d6ee21f31cf2a3b2349ae41499048572fc0e9.0
  # or 
  yarn add @infineon/infineon-icons@1.1.8--canary.22.da4d6ee21f31cf2a3b2349ae41499048572fc0e9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
