### PR TITLE
link in readme fixed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@
   <h3 align="center">infineon-icons</h3>
 
   <p align="center">
-    Include SVG Icons from <a href="https://infineon.github.io/infineon-design-system-stencil/?path=/story/icons--page">Infineon's Icon Library</a> into your project
+    Include SVG Icons from <a href="https://infineon.github.io/infineon-design-system-stencil/?path=/docs/icon-library--development">Infineon's Icon Library</a> into your project
     <br />
     <a href="https://github.com/infineon/infineon-icons"><strong>Explore the docs »</strong></a>
     <br />


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Readme updated with the correct link to the Icons Demo Page on Storybook
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.9--canary.28.df4cfab001d719518e3f33598c58f92b3607878e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-icons@1.1.9--canary.28.df4cfab001d719518e3f33598c58f92b3607878e.0
  # or 
  yarn add @infineon/infineon-icons@1.1.9--canary.28.df4cfab001d719518e3f33598c58f92b3607878e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
