### PR TITLE
Reverted change of icon name output format

### DIFF
--- a/build/generate.js
+++ b/build/generate.js
@@ -54,18 +54,17 @@ const computeFileHash = async (filePath) => {
 };
 
 const generateJSFiles = async (icons) => {
-  const makeLowerCase = (str) => str.toLowerCase().replace(/[^a-zA-Z0-9]+/g, '');
+  const makeCamelCase = (str) => str.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase());
 
-  const svgImports = icons.map((icon) => `import ${makeLowerCase(icon)}Icon from ".${svgSourceFolder}${icon}.svg";`).join('\n');
+  const svgImports = icons.map((icon) => `import ${makeCamelCase(icon)}Icon from ".${svgSourceFolder}${icon}.svg";`).join('\n');
 
   const iconsObject = `export const icons = {\n${
-    icons.map((icon) => `  ${makeLowerCase(icon)}: ${makeLowerCase(icon)}Icon`).join(',\n')
+    icons.map((icon) => `  ${makeCamelCase(icon)}: ${makeCamelCase(icon)}Icon`).join(',\n')
   }};`;
 
   const getIconFunction = 'export const getIcon = (icon) => icons[icon];';
 
-  const indexFileRegistryContent = `export const iconRegistry = {};\n${
-    icons.map((icon) => `export const ${makeLowerCase(icon)} = () => iconRegistry["${makeLowerCase(icon)}"] = ${makeLowerCase(icon)}Icon;`).join('\n')}`;
+  const indexFileRegistryContent = `export const iconRegistry = {};\n${icons.map((icon) => `export const ${makeCamelCase(icon)} = () => iconRegistry["${makeCamelCase(icon)}"] = ${makeCamelCase(icon)}Icon;`).join('\n')}`;
 
   const data = [
     svgImports,


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Icon names will be camelCase again - better readabilitiy
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.4.1--canary.89.d43561434a6639146a48f6a8f9b95687f6390ebd.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-icons@4.4.1--canary.89.d43561434a6639146a48f6a8f9b95687f6390ebd.0
  # or 
  yarn add @infineon/infineon-icons@4.4.1--canary.89.d43561434a6639146a48f6a8f9b95687f6390ebd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
