### PR TITLE
fix: add require/default exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   "types": "dist/icons.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/icons.d.ts",
       "import": "./dist/icons.js",
-      "types": "./dist/icons.d.ts"
+      "require": "./dist/icons.js",
+      "default": "./dist/icons.js"
     }
   },
   "files": [


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Export configuration needed for CJS
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.7.4--canary.109.495240bc779675dbb55edc226d031fc00307bc45.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-icons@4.7.4--canary.109.495240bc779675dbb55edc226d031fc00307bc45.0
  # or 
  yarn add @infineon/infineon-icons@4.7.4--canary.109.495240bc779675dbb55edc226d031fc00307bc45.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
